### PR TITLE
[AT-722] Replace deprecated GitHub Actions secrets

### DIFF
--- a/.github/workflows/update-gutenberg-versions.yml
+++ b/.github/workflows/update-gutenberg-versions.yml
@@ -29,8 +29,8 @@ jobs:
 
             - name: Add, Commit, and Push
               run: |
-                  git config user.email ${{ secrets.INPSYDE_BOT_EMAIL }}
-                  git config user.name ${{ secrets.INPSYDE_BOT_USER }}
+                  git config user.email ${{ secrets.DEPLOYBOT_EMAIL }}
+                  git config user.name ${{ secrets.DEPLOYBOT_USER }}
                   git config --add safe.directory "${GITHUB_WORKSPACE}"
                   git add ./versions/* --ignore-errors
                   git add ./versions.txt --ignore-errors


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Chore


**What is the current behavior?** (You can also link to an open issue here)
https://inpsyde.atlassian.net/browse/AT-722
Two deprecated GitHub Actions secrets are used: `INPSYDE_BOT_EMAIL` and `INPSYDE_BOT_USER`.


**What is the new behavior (if this is a feature change)?**
The deprecated secrets are replaced with their current counterparts: `DEPLOYBOT_EMAIL` and `DEPLOYBOT_USER`.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


**Other information**:
